### PR TITLE
Updated to hath v1.6.0

### DIFF
--- a/hooks/.config
+++ b/hooks/.config
@@ -16,4 +16,4 @@ build_architectures=(amd64 aarch64 arm)
 
 docker -v
 
-hath_version=1.4.2
+hath_version=1.6.0


### PR DESCRIPTION
Latest stable H@H release, required by service starting February 1st to continue use. See https://forums.e-hentai.org/index.php?showtopic=234458