### PR TITLE
2024-12-15T06:48:36Z [WARN] Rejecting connection request from 172.17.0.1 during startup.

### DIFF
--- a/run/start.sh
+++ b/run/start.sh
@@ -15,5 +15,6 @@ exec java -jar /opt/hath/HentaiAtHome.jar \
     --data-dir=/hath/data                 \
     --download-dir=/hath/download         \
     --log-dir=/hath/log                   \
-    --temp-dir=/hath/tmp
+    --temp-dir=/hath/tmp                  \
+    --disable-ip-origin-check
 


### PR DESCRIPTION
* https://github.com/frosty5689/docker-hath/pull/1#issuecomment-416385686

Hi, H@H added `--disable-ip-origin-check` to solve this in October 2019.

- https://forums.e-hentai.org/index.php?showtopic=232693