### PR TITLE
Update openjdk8 tag

### DIFF
--- a/.github/workflows/docker-hub-build-and-push.yml
+++ b/.github/workflows/docker-hub-build-and-push.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "master"
 env:
-  HATH_VERSION: 1.6.4
+  HATH_VERSION: 1.6.5
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u212-jre-alpine
 
 LABEL maintainer frosty5689 <frosty5689@gmail.com>
 


### PR DESCRIPTION
openjdk:8-jre-alpine tag was deleted. Needs openjdk:8u212-jre-alpine now. 